### PR TITLE
Update for unit tests on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 .cproject
 .project
 /.idea/
+/.vscode/
+/.history/
 /coverage/
 /cmake-build-debug/
 
@@ -38,6 +40,9 @@
 /test/*.tmp
 /vendor/
 /datagen/
+/build/
+CMakeUserPresets.json
+*.swp
 
 # Legacy locations of generated files (no longer in use)
 /src/boxes
@@ -56,6 +61,9 @@
 /tools/LICENSE.txt
 /boxes.portable.*.nupkg
 *.nupkg.zip
+
+# MacOS
+.DS_Store
 
 # Misc
 /vs

--- a/Makefile
+++ b/Makefile
@@ -44,18 +44,35 @@ WIN_CMOCKA_DIR         = vendor/cmocka-$(WIN_CMOCKA_VERSION)
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#    Detect platform (Apple's linker does not support --wrap)
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+BOXES_PLATFORM := ""
+ifeq ($(OS),Windows_NT)
+	BOXES_PLATFORM := win32
+else
+	UNAME_S := $(shell sh -c 'uname -s 2>/dev/null || echo Unknown')
+	ifeq ($(UNAME_S),Darwin)
+		BOXES_PLATFORM := darwin
+	else
+		BOXES_PLATFORM := unix
+	endif
+endif
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #    Build
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 build cov debug: infomsg replaceinfos
-	$(MAKE) -C src BOXES_PLATFORM=unix LEX=$(LEX) YACC=$(YACC) $@
+	$(MAKE) -C src BOXES_PLATFORM=$(BOXES_PLATFORM) LEX=$(LEX) YACC=$(YACC) $@
 
 win32: infomsg replaceinfos
-	$(MAKE) -C src BOXES_PLATFORM=win32 C_INCLUDE_PATH=../$(PCRE2_DIR)/src LDFLAGS=-L../$(PCRE2_DIR)/.libs \
+	$(MAKE) -C src BOXES_PLATFORM=$(BOXES_PLATFORM) C_INCLUDE_PATH=../$(PCRE2_DIR)/src LDFLAGS=-L../$(PCRE2_DIR)/.libs \
 	    LEX=../$(WIN_FLEX_BISON_DIR)/win_flex.exe YACC=../$(WIN_FLEX_BISON_DIR)/win_bison.exe build
 
 win32.debug: infomsg replaceinfos
-	$(MAKE) -C src BOXES_PLATFORM=win32 C_INCLUDE_PATH=../$(PCRE2_DIR)/src LDFLAGS=-L../$(PCRE2_DIR)/.libs \
+	$(MAKE) -C src BOXES_PLATFORM=$(BOXES_PLATFORM) C_INCLUDE_PATH=../$(PCRE2_DIR)/src LDFLAGS=-L../$(PCRE2_DIR)/.libs \
 	    LEX=../$(WIN_FLEX_BISON_DIR)/win_flex.exe YACC=../$(WIN_FLEX_BISON_DIR)/win_bison.exe debug
 
 win32.prereq: $(PCRE2_DIR)/.libs/libpcre2-32.a vendor/win_flex_bison-$(WIN_FLEX_BISON_VERSION).zip \
@@ -155,7 +172,7 @@ $(OUT_DIR)/zip/$(PKG_NAME).zip:
 	@echo Windows ZIP file created at $(OUT_DIR)/zip/$(PKG_NAME).zip
 
 package: build
-	$(MAKE) BOXES_PLATFORM=unix $(PKG_NAME).tar.gz
+	$(MAKE) BOXES_PLATFORM=$(BOXES_PLATFORM) $(PKG_NAME).tar.gz
 
 win32.package: win32 $(OUT_DIR)/zip/$(PKG_NAME).zip
 
@@ -190,11 +207,11 @@ covtest:
 	cd test; ./testrunner.sh --suite --coverage
 
 utest:
-	$(MAKE) -C utest BOXES_PLATFORM=unix utest
+	$(MAKE) -C utest BOXES_PLATFORM=$(BOXES_PLATFORM) utest
 
 win32.utest: $(OUT_DIR)
 	cp $(WIN_CMOCKA_DIR)/bin/cmocka.dll $(OUT_DIR)/
-	$(MAKE) -C utest BOXES_PLATFORM=win32 C_INCLUDE_PATH=../$(PCRE2_DIR)/src:../$(WIN_CMOCKA_DIR)/include \
+	$(MAKE) -C utest BOXES_PLATFORM=$(BOXES_PLATFORM) C_INCLUDE_PATH=../$(PCRE2_DIR)/src:../$(WIN_CMOCKA_DIR)/include \
 	    LDFLAGS_ADDTL="-L../$(PCRE2_DIR)/.libs -L../$(WIN_CMOCKA_DIR)/lib" utest
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ ORIG_SRC   = $(ORIG_GEN) $(ORIG_NORM)
 ORIG_FILES = $(ORIG_SRC) $(ORIG_HDR)
 
 
-.PHONY: boxes.static check_dir clean build cov debug package static flags_unix flags_static flags_win32 flags_
+.PHONY: boxes.static check_dir clean build cov debug package static flags_unix flags_darwin flags_static flags_win32 flags_
 
 .NOTPARALLEL:
 
@@ -76,7 +76,7 @@ boxes.exe: $(ALL_OBJ) | check_dir
 	if [ "$(STRIP)" = "true" ] ; then strip $@ ; fi
 
 
-flags_unix:
+flags_unix flags_darwin:
 	$(eval CFLAGS := -I. -I$(SRC_DIR) -Wall -W $(CFLAGS_ADDTL))
 	$(eval LDFLAGS := $(LDFLAGS) $(LDFLAGS_ADDTL))
 	$(eval BOXES_EXECUTABLE_NAME := boxes)

--- a/src/tools.c
+++ b/src/tools.c
@@ -42,6 +42,15 @@
 static pcre2_code *pattern_ascii_id = NULL;
 static pcre2_code *pattern_ascii_id_strict = NULL;
 
+/**
+ * Initialize the `bx_fprintf` function pointer to point to the original
+ * `bx_fprintf` function, now renamed `bx_fprintf_original`. During unit
+ * tests, this will be replaced with `__wrap_bx_fprintf`, which stores
+ * the result that would have been printed so the output can be validated.
+ * This is necessary for unit testing and CI to work with MacOS.
+ */
+bx_fprintf_t bx_fprintf = bx_fprintf_original;
+
 
 static pcre2_code *get_pattern_ascii_id(int strict)
 {
@@ -849,7 +858,7 @@ char *bx_strndup(const char *s, size_t n)
 
 
 
-void bx_fprintf(FILE *stream, const char *format, ...)
+void bx_fprintf_original(FILE *stream, const char *format, ...)
 {
     va_list va;
     va_start(va, format);
@@ -857,6 +866,10 @@ void bx_fprintf(FILE *stream, const char *format, ...)
     va_end(va);
 }
 
+
+void set_bx_fprintf(bx_fprintf_t bx_fprintf_function) {
+    bx_fprintf = bx_fprintf_function;
+}
 
 
 FILE *bx_fopens(bxstr_t *pathname, char *mode)

--- a/src/tools.h
+++ b/src/tools.h
@@ -40,6 +40,18 @@
 }
 
 
+/**
+ * Define type for a function pointer to specify which `bx_fprintf` function
+ * will be called. This enables unit testing on MacOS, since Apple's `ld`
+ * linker does not support the `--wrap` flag that GNU `ld` does.
+ */
+typedef void (*bx_fprintf_t)(FILE *stream, const char *format, ...);
+
+/**
+ * Declare function pointer to be changed when running unit tests
+ */
+extern bx_fprintf_t bx_fprintf;
+
 int empty_line(const line_t *line);
 
 
@@ -173,7 +185,7 @@ int tag_is_valid(char *tag);
 
 /**
  * Duplicate at most `n` bytes from the given string `s`.  Memory for the new string is obtained with `malloc()`, and
- * can be freed with `free()`. A terminating null byte is added. We include this implementation because the libc's 
+ * can be freed with `free()`. A terminating null byte is added. We include this implementation because the libc's
  * `strndup()` is not consistently available across all platforms.
  * @param s a string
  * @param n maximum number of characters to copy (excluding the null byte)
@@ -187,8 +199,13 @@ char *bx_strndup(const char *s, size_t n);
  * @param stream Where to print, for example `stderr`
  * @param format the format string, followed by the arguments of the format string
  */
-void bx_fprintf(FILE *stream, const char *format, ...);
+void bx_fprintf_original(FILE *stream, const char *format, ...);
 
+
+/**
+ * Set the bx_fprintf_ptr function pointer to point to a specific function
+ */
+void set_bx_fprintf(bx_fprintf_t func_to_use);
 
 /**
  * Determine if the given string is an "ASCII ID", which means:

--- a/src/tools.h
+++ b/src/tools.h
@@ -205,7 +205,7 @@ void bx_fprintf_original(FILE *stream, const char *format, ...);
 /**
  * Set the bx_fprintf_ptr function pointer to point to a specific function
  */
-void set_bx_fprintf(bx_fprintf_t func_to_use);
+void set_bx_fprintf(bx_fprintf_t bx_fprintf_function);
 
 /**
  * Determine if the given string is an "ASCII ID", which means:

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -23,7 +23,7 @@ UTEST_NORM = global_mock.c bxstring_test.o cmdline_test.c tools_test.c regulex_t
              utest_tools.o
 MOCKS      = bx_fprintf
 
-.PHONY: check_dir flags_unix flags_win32 flags_ utest
+.PHONY: check_dir flags_unix flags_darwin flags_win32 flags_ utest
 
 .NOTPARALLEL:
 
@@ -39,6 +39,12 @@ $(OUT_DIR):
 flags_unix:
 	$(eval CFLAGS := -I. -I$(SRC_DIR) -O -Wall -W -Wno-stringop-overflow $(CFLAGS_ADDTL))
 	$(eval LDFLAGS := $(LDFLAGS) $(foreach MOCK,$(MOCKS),-Wl,--wrap=$(MOCK)) --coverage $(LDFLAGS_ADDTL))
+	$(eval UTEST_EXECUTABLE_NAME := unittest)
+	$(eval UTEST_OBJ := $(UTEST_NORM:.c=.o))
+
+flags_darwin:
+	$(eval CFLAGS := -I. -I$(SRC_DIR) -O -Wall -W -Wno-stringop-overflow $(CFLAGS_ADDTL))
+	$(eval LDFLAGS := $(LDFLAGS) --coverage $(LDFLAGS_ADDTL))
 	$(eval UTEST_EXECUTABLE_NAME := unittest)
 	$(eval UTEST_OBJ := $(UTEST_NORM:.c=.o))
 

--- a/utest/global_mock.c
+++ b/utest/global_mock.c
@@ -101,6 +101,7 @@ void setup_mocks()
     setlocale(LC_ALL, "");
     encoding = check_encoding("UTF-8", locale_charset());
     collect_reset();
+    set_bx_fprintf(__wrap_bx_fprintf);
 }
 
 


### PR DESCRIPTION
- Change `bx_fprintf` function to a function pointer
  - Point `bx_fprintf` at the original function under normal operation
  - `setup_mocks()` changes the function pointer to point to `__wrap_bx_fprintf()`
- `Makefile`s updated to customize macOS build process
- Minor additions to `.gitignore` to ignore files from VS Code, JetBrains CLion, and macOS Finder